### PR TITLE
[Cleanup] Remove redundant factory registration comments in Cosserat module

### DIFF
--- a/src/Cosserat/constraint/CosseratActuatorConstraint.cpp
+++ b/src/Cosserat/constraint/CosseratActuatorConstraint.cpp
@@ -33,35 +33,20 @@
 #include <Cosserat/config.h>
 #include <sofa/core/ObjectFactory.h>
 
-namespace Cosserat
 
+namespace Cosserat
 {
 
-//////////////////////////////////////CosseratActuatorConstraintConstraintResolution1Dof/////////////////////////////////////////////
 using namespace sofa::defaulttype;
 using namespace sofa::helper;
 using namespace sofa::core;
 
-////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
-// Registering the component
-// see: http://wiki.sofa-framework.org/wiki/ObjectFactory
-// 1-RegisterObject("description") + .add<> : Register the component
-// 2-.add<>(true) : Set default template
 
 void registerCosseratActuatorConstraint(sofa::core::ObjectFactory* factory)
 {
       factory->registerObjects(sofa::core::ObjectRegistrationData("Simulate cable actuation.")
             .add< sofa::component::constraintset::CosseratActuatorConstraint<Vec3Types> >(true));
-}
-
-;
-////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// Force template specialization for the most common sofa type.
-// This goes with the extern template declaration in the .h. Declaring extern template
-// avoid the code generation of the template for each compilation unit.
-// see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
-//template class CosseratActuatorConstraint<Vec3Types>;
+};
 
 } // namespace sofa
 

--- a/src/Cosserat/constraint/CosseratNeedleSlidingConstraint.cpp
+++ b/src/Cosserat/constraint/CosseratNeedleSlidingConstraint.cpp
@@ -31,18 +31,11 @@
 #include "CosseratNeedleSlidingConstraint.inl"
 
 
-
 namespace Cosserat {
 
 using sofa::defaulttype::Rigid3Types;
 using namespace sofa::helper;
 using namespace sofa::core;
-
-////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
-// Registering the component
-// see: http://wiki.sofa-framework.org/wiki/ObjectFactory
-// 1-RegisterObject("description") + .add<> : Register the component
-// 2-.add<>(true) : Set default template
 
 void registerCosseratNeedleSlidingConstraint(
     sofa::core::ObjectFactory *factory) {
@@ -51,4 +44,4 @@ void registerCosseratNeedleSlidingConstraint(
 
 }
 
-} // namespace sofa
+} // namespace Cosserat

--- a/src/Cosserat/constraint/QPSlidingConstraint.cpp
+++ b/src/Cosserat/constraint/QPSlidingConstraint.cpp
@@ -76,28 +76,11 @@ void SlidingForceConstraintResolution::resolution(int line, double **w,
 namespace Cosserat
 {
 
-////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
-// Registering the component
-// see: http://wiki.sofa-framework.org/wiki/ObjectFactory
-// 1-RegisterObject("description") + .add<> : Register the component
-// 2-.add<>(true) : Set default template
-
 void registerQPSlidingConstraint(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Simulate cable actuation.")
     .add< sofa::component::constraintset::QPSlidingConstraint<sofa::defaulttype::Vec3Types> >(true));
 }
-
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// Force template specialization for the most common sofa type.
-// This goes with the extern template declaration in the .h. Declaring extern template
-// avoid the code generation of the template for each compilation unit.
-// see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
-//template class QPSlidingConstraint<sofa::defaulttype::Vec3Types>;
-
-
 } // namespace Cosserat
 
 

--- a/src/Cosserat/forcefield/BeamHookeLawForceField.cpp
+++ b/src/Cosserat/forcefield/BeamHookeLawForceField.cpp
@@ -174,15 +174,6 @@ template class BeamHookeLawForceField<Vec6Types>;
 
 namespace Cosserat
 {
-////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
-// Registering the component
-// see: http://wiki.sofa-framework.org/wiki/ObjectFactory
-// 1-RegisterObject("description") + .add<> : Register the component
-// 2-.add<>(true) : Set default template
-
-
-
-
 void registerBeamHookeLawForceField(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(
@@ -191,12 +182,6 @@ void registerBeamHookeLawForceField(sofa::core::ObjectFactory* factory)
             .add<sofa::component::forcefield::BeamHookeLawForceField<sofa::defaulttype::Vec3Types>>(true)
             .add<sofa::component::forcefield::BeamHookeLawForceField<sofa::defaulttype::Vec6Types>>());
 }
-//////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// Force template specialization for the most common sofa floating point related type.
-// This goes with the extern template declaration in the .h. Declaring extern template
-// avoid the code generation of the template for each compilation unit.
-// see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
 
 
-} // forcefield
+} // Cosserat

--- a/src/Cosserat/forcefield/BeamHookeLawForceFieldRigid.cpp
+++ b/src/Cosserat/forcefield/BeamHookeLawForceFieldRigid.cpp
@@ -37,12 +37,6 @@ using namespace sofa::defaulttype;
 namespace Cosserat
 {
 
-////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
-// Registering the component
-// see: http://wiki.sofa-framework.org/wiki/ObjectFactory
-// 1-RegisterObject("description") + .add<> : Register the component
-// 2-.add<>(true) : Set default template
-
 void registerBeamHookeLawForceFieldRigid(sofa::core::ObjectFactory *factory) {
   factory->registerObjects(
       sofa::core::ObjectRegistrationData(
@@ -51,9 +45,6 @@ void registerBeamHookeLawForceFieldRigid(sofa::core::ObjectFactory *factory) {
           .add<sofa::component::forcefield::BeamHookeLawForceFieldRigid<
               Vec6Types>>());
 }
-//////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// Force template specialization for the most common sofa floating point related type. This goes with the extern template declaration in the .h. Declaring extern template avoid the code generation of the template for each compilation unit. see: http://www.stroustrup.com/C++11FAQ.html#extern-templates
 }
 
 namespace sofa::component::forcefield

--- a/src/Cosserat/forcefield/CosseratInternalActuation.cpp
+++ b/src/Cosserat/forcefield/CosseratInternalActuation.cpp
@@ -33,11 +33,6 @@
 
 namespace Cosserat
 {
-////////////////////////////////////////////    FACTORY    //////////////////////////////////////////////
-// Registering the component
-// see: http://wiki.sofa-framework.org/wiki/ObjectFactory
-// 1-RegisterObject("description") + .add<> : Register the component
-// 2-.add<>(true) : Set default template
 using namespace sofa::defaulttype;
 
 void registerCosseratInternalActuation(sofa::core::ObjectFactory *factory) {
@@ -46,7 +41,6 @@ void registerCosseratInternalActuation(sofa::core::ObjectFactory *factory) {
           "This component is used to compute internal stress for torsion (along x) and bending (y and z)")
           .add<sofa::component::forcefield::CosseratInternalActuation<Vec3Types>>(true));
 }
-//////////////////////////////////////////////////////////////////////////////////////////////////////
 
 }
 


### PR DESCRIPTION
- Eliminated verbose comments detailing factory registration steps across multiple files in the Cosserat module.
- Simplified namespace declarations and cleaned up extraneous formatting.
- Improved code readability by removing outdated or redundant commentary.
This commit does not affect the functionality of the module but enhances maintainability by reducing clutter.
This is here to complete the PR:  https://github.com/SofaDefrost/Cosserat/pull/141

